### PR TITLE
feat: redesign hero section with mathematical animations and add contributors

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,4 +1,5 @@
 import Footer from "@/components/home/Footer";
+import Contributors from "@/components/about/Contributors";
 import {
     Card,
     CardContent,
@@ -541,7 +542,7 @@ export default async function AboutPage() {
                                 asChild
                             >
                                 <a 
-                                    href="https://drive.google.com/file/d/1pgNEsjNPELy0Q9bL-PL-w9w7ifsfuxn7/view" 
+                                    href="https://vwkhuivnxctstkhzrext.supabase.co/storage/v1/object/public/public_bucket/The%20Constitution%20of%20ACPSCM%20Vol%200_1.pdf" 
                                     target="_blank" 
                                     rel="noopener noreferrer"
                                     className="inline-flex items-center gap-2"
@@ -714,6 +715,8 @@ export default async function AboutPage() {
                     )}
                 </div>
             </section>
+
+            <Contributors />
 
             <Footer />
         </main>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700;800&display=swap');
 @import "tailwindcss";
 @import "tw-animate-css";
 
@@ -168,6 +169,18 @@
     --shadow-lg: var(--shadow-lg);
     --shadow-xl: var(--shadow-xl);
     --shadow-2xl: var(--shadow-2xl);
+    --animate-shine: shine var(--duration) infinite linear;
+  @keyframes shine {
+  0% {
+    background-position: 0% 0%;
+        }
+  50% {
+    background-position: 100% 100%;
+        }
+  to {
+    background-position: 0% 0%;
+        }
+    }
 }
 
 /* Custom scrollbar */
@@ -201,6 +214,15 @@
     body {
         @apply bg-background text-foreground;
         pointer-events: auto !important;
+    font-family: 'Montserrat', var(--font-sans);
+    }
+    a[href], button, [role="button"], input[type="button"], input[type="submit"] {
+        cursor: pointer;
+    }
+    button:disabled,
+    input[disabled],
+    [aria-disabled="true"] {
+        cursor: default;
     }
 }
 
@@ -224,4 +246,28 @@
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 3;
+}
+
+::view-transition-old(root), ::view-transition-new(root) {
+    animation: none;
+    mix-blend-mode: normal;
+}
+
+@keyframes float {
+    0%, 100% {
+        transform: translateY(0px) translateX(0px);
+        opacity: 0.7;
+    }
+    25% {
+        transform: translateY(-10px) translateX(5px);
+        opacity: 0.8;
+    }
+    50% {
+        transform: translateY(-5px) translateX(-5px);
+        opacity: 0.9;
+    }
+    75% {
+        transform: translateY(-15px) translateX(3px);
+        opacity: 0.75;
+    }
 }

--- a/components.json
+++ b/components.json
@@ -10,6 +10,7 @@
     "cssVariables": true,
     "prefix": ""
   },
+  "iconLibrary": "lucide",
   "aliases": {
     "components": "@/components",
     "utils": "@/lib/utils",
@@ -17,5 +18,7 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "iconLibrary": "lucide"
+  "registries": {
+    "@magicui": "https://magicui.design/r/{name}.json"
+  }
 }

--- a/components/about/Contributors.tsx
+++ b/components/about/Contributors.tsx
@@ -1,0 +1,87 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Github, GitCommit, ExternalLink } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+interface GitHubContributor {
+    login: string;
+    id: number;
+    avatar_url: string;
+    html_url: string;
+    contributions: number;
+    type: string;
+}
+
+async function getContributors(): Promise<GitHubContributor[]> {
+    try {
+        const response = await fetch(
+            "https://api.github.com/repos/Abrar118/ACPMS-Website/contributors",
+            {
+                headers: {
+                    Accept: "application/vnd.github.v3+json",
+                },
+                // Revalidate every 24 hours
+                next: { revalidate: 86400 },
+            }
+        );
+
+        if (!response.ok) {
+            console.error("Failed to fetch contributors:", response.statusText);
+            return [];
+        }
+
+        const data = await response.json();
+        return data;
+    } catch (error) {
+        console.error("Error fetching contributors:", error);
+        return [];
+    }
+}
+
+export default async function Contributors() {
+    const contributors = await getContributors();
+
+    if (contributors.length === 0) {
+        return null;
+    }
+
+    return (
+        <section className="py-16 px-4">
+            <div className="max-w-6xl mx-auto">
+                <div className="text-center mb-8">
+                    <h2 className="text-3xl font-bold mb-2">Contributors</h2>
+                    <p className="text-muted-foreground">
+                        Thank you to everyone who contributed to this project
+                    </p>
+                </div>
+
+                <Card className="p-6">
+                    <div className="flex flex-wrap justify-start gap-3">
+                        {contributors.map((contributor) => (
+                            <Link
+                                key={contributor.id}
+                                href={contributor.html_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="group"
+                                title={`${contributor.login}`}
+                            >
+                                <Avatar className="w-12 h-12 ring-2 ring-border group-hover:ring-primary/90 transition-all duration-300 group-hover:scale-110">
+                                    <AvatarImage
+                                        src={contributor.avatar_url}
+                                        alt={contributor.login}
+                                    />
+                                    <AvatarFallback className="bg-primary/10 text-primary font-semibold text-xs">
+                                        {contributor.login.slice(0, 2).toUpperCase()}
+                                    </AvatarFallback>
+                                </Avatar>
+                            </Link>
+                        ))}
+                    </div>
+                </Card>
+            </div>
+        </section>
+    );
+}

--- a/components/home/HeroSection.tsx
+++ b/components/home/HeroSection.tsx
@@ -1,64 +1,253 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
 import { ChevronDown } from "lucide-react";
 import Link from "next/link";
+import { HyperText } from "../ui/hyper-text";
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { Particles } from "../ui/particles";
+import { ShineBorder } from "../ui/shine-border";
 
 export default function HeroSection() {
-    return (
-        <section className="relative min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">
-            {/* Background with mathematical formulas */}
-            <div className="absolute inset-0 overflow-hidden">
-                <div className="absolute inset-0 opacity-90 dark:opacity-50">
-                    <div className="text-emerald-400 font-mono text-lg tracking-wider absolute top-10 left-10 rotate-12 animate-pulse">
-                        ∫₀^∞ e^(-x²) dx = √π/2
-                    </div>
-                    <div className="text-blue-400 font-mono text-sm absolute top-20 right-20 -rotate-6 animate-pulse delay-1000">
-                        lim(x→0) (sin x)/x = 1
-                    </div>
-                    <div className="text-purple-400 font-mono text-base absolute bottom-32 left-16 rotate-6 animate-pulse delay-2000">
-                        ∇²φ = ρ/ε₀
-                    </div>
-                    <div className="text-yellow-400 font-mono text-lg absolute bottom-20 right-24 -rotate-12 animate-pulse delay-3000">
-                        e^(iπ) + 1 = 0
-                    </div>
-                    <div className="text-red-400 font-mono text-sm absolute top-1/3 left-1/4 rotate-3 animate-pulse delay-500">
-                        ∂f/∂x = lim(h→0) [f(x+h)-f(x)]/h
-                    </div>
-                    <div className="text-cyan-400 font-mono text-base absolute top-2/3 right-1/3 -rotate-3 animate-pulse delay-1500">
-                        ∑(n=1 to ∞) 1/n² = π²/6
-                    </div>
-                </div>
-            </div>
+  const { resolvedTheme } = useTheme();
+  const [color, setColor] = useState("#ffffff");
+  useEffect(() => {
+    setColor(resolvedTheme === "dark" ? "#ffffff" : "#000000");
+  }, [resolvedTheme]);
 
-            {/* Main content */}
-            <div className="relative z-10 text-center px-4 max-w-6xl mx-auto">
-                <h1 className="text-5xl md:text-7xl font-bold mb-6 bg-gradient-to-r from-blue-400 via-purple-400 to-pink-400 bg-clip-text text-transparent">
-                    ACPS Club of Mathematics
-                </h1>
-                <p className="text-xl md:text-2xl mb-8 text-gray-200 dark:text-gray-300 font-light">
-                    Think Logical
-                </p>
-                <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                    <Link href="/auth?tab=register">
-                        <Button size="lg" className="px-8 py-3 text-lg">
-                            Join Now
-                        </Button>
-                    </Link>
-                    <Link href="/resources">
-                        <Button
-                            size="lg"
-                            variant="outline"
-                            className="bg-[#2a3040] border-gray-200 text-gray-200 hover:bg-gray-200 hover:text-gray-900 px-8 py-3 text-lg"
-                        >
-                            Explore Resources
-                        </Button>
-                    </Link>
-                </div>
-            </div>
+  return (
+    <section className="relative select-none min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 overflow-hidden">
+      <div className="absolute inset-0 bg-black/10 dark:bg-black/50 pointer-events-none z-10" />
+      <div className="absolute inset-0 overflow-hidden">
+        <Particles
+          className="absolute inset-0 z-0"
+          quantity={100}
+          ease={80}
+          color={color}
+          refresh
+        />
+      </div>
 
-            {/* Scroll indicator */}
-            <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 text-gray-200 animate-bounce">
-                <ChevronDown className="w-6 h-6" />
-            </div>
-        </section>
-    );
+      <div className="absolute inset-0 bg-gradient-to-b from-transparent via-slate-900/20 to-transparent pointer-events-none z-10" />
+
+      <div className="absolute inset-0 overflow-hidden opacity-30 dark:opacity-25 z-20">
+        <div
+          className="absolute top-1/4 left-10 w-32 h-32 border-2 border-blue-400/50 rounded-full"
+          style={{ animation: "pulse 4s ease-in-out infinite" }}
+        />
+        <div
+          className="absolute bottom-1/4 right-20 w-40 h-40 border-2 border-purple-400/50 rotate-45"
+          style={{
+            animation:
+              "spin 20s linear infinite, pulse 3s ease-in-out infinite",
+          }}
+        />
+        <div
+          className="absolute top-1/3 right-1/4 w-24 h-24 border-2 border-pink-400/50 rounded-full"
+          style={{ animation: "pulse 3s ease-in-out infinite 1s" }}
+        />
+        <div
+          className="absolute bottom-1/3 left-1/4 w-36 h-36 border-2 border-cyan-400/50 rotate-12"
+          style={{
+            animation:
+              "spin 25s linear infinite reverse, pulse 4.5s ease-in-out infinite",
+          }}
+        />
+        <div
+          className="absolute top-1/2 right-1/3 w-28 h-28 border-2 border-emerald-400/50"
+          style={{
+            animation:
+              "spin 30s linear infinite, pulse 5s ease-in-out infinite 2s",
+          }}
+        />
+      </div>
+
+      <div className="absolute inset-0 overflow-hidden z-20">
+        <div
+          className="absolute top-20 left-1/4 text-6xl text-blue-300/10 dark:text-blue-400/10 font-bold select-none"
+          style={{ animation: "float 8s ease-in-out infinite" }}
+        >
+          π
+        </div>
+        <div
+          className="absolute bottom-32 right-1/4 text-7xl text-purple-300/10 dark:text-purple-400/10 font-bold select-none"
+          style={{ animation: "float 9s ease-in-out infinite 1s" }}
+        >
+          ∑
+        </div>
+        <div
+          className="absolute top-1/2 left-12 text-5xl text-pink-300/10 dark:text-pink-400/10 font-bold select-none"
+          style={{ animation: "float 7.5s ease-in-out infinite 2s" }}
+        >
+          ∫
+        </div>
+        <div
+          className="absolute top-1/3 right-16 text-8xl text-cyan-300/10 dark:text-cyan-400/10 font-bold select-none"
+          style={{ animation: "float 10s ease-in-out infinite 0.5s" }}
+        >
+          ∞
+        </div>
+        <div
+          className="absolute bottom-1/5 left-2/5 text-6xl text-emerald-300/10 dark:text-emerald-400/10 font-bold select-none"
+          style={{ animation: "float 8.5s ease-in-out infinite 1.5s" }}
+        >
+          Σ
+        </div>
+        <div
+          className="absolute top-2/3 right-1/3 text-5xl text-yellow-300/10 dark:text-yellow-400/10 font-bold select-none"
+          style={{ animation: "float 9.5s ease-in-out infinite 2.5s" }}
+        >
+          √
+        </div>
+      </div>
+
+      <div className="absolute inset-0 overflow-hidden z-5 pointer-events-none">
+        <div
+          className="absolute top-16 left-16 text-blue-400/70 dark:text-blue-400/60 font-mono text-sm backdrop-blur-sm bg-slate-900/30 dark:bg-slate-900/40 px-3 py-2 rounded-lg border border-blue-400/30 transform -rotate-6"
+          style={{ animation: "float 6s ease-in-out infinite" }}
+        >
+          ∫₀^∞ e^(-x²)dx = √π/2
+        </div>
+        <div
+          className="absolute top-24 right-20 text-purple-400/70 dark:text-purple-400/60 font-mono text-sm backdrop-blur-sm bg-slate-900/30 dark:bg-slate-900/40 px-3 py-2 rounded-lg border border-purple-400/30 transform rotate-3"
+          style={{ animation: "float 7s ease-in-out infinite 1s" }}
+        >
+          lim(x→0) (sin x)/x = 1
+        </div>
+        <div
+          className="absolute bottom-24 left-24 text-pink-400/70 dark:text-pink-400/60 font-mono text-base backdrop-blur-sm bg-slate-900/30 dark:bg-slate-900/40 px-3 py-2 rounded-lg border border-pink-400/30 transform rotate-6"
+          style={{ animation: "float 5.5s ease-in-out infinite 2s" }}
+        >
+          e^(iπ) + 1 = 0
+        </div>
+        <div
+          className="absolute bottom-32 right-32 text-cyan-400/70 dark:text-cyan-400/60 font-mono text-sm backdrop-blur-sm bg-slate-900/30 dark:bg-slate-900/40 px-3 py-2 rounded-lg border border-cyan-400/30 transform -rotate-3"
+          style={{ animation: "float 6.5s ease-in-out infinite 0.5s" }}
+        >
+          ∑(n=1→∞) 1/n² = π²/6
+        </div>
+        <div
+          className="absolute top-1/3 right-12 text-emerald-400/70 dark:text-emerald-400/60 font-mono text-xs backdrop-blur-sm bg-slate-900/30 dark:bg-slate-900/40 px-2 py-1 rounded-lg border border-emerald-400/30 transform rotate-12"
+          style={{ animation: "float 7.5s ease-in-out infinite 1.5s" }}
+        >
+          ∇²f = ∂²f/∂x² + ∂²f/∂y²
+        </div>
+        <div
+          className="absolute top-1/2 left-20 text-yellow-400/70 dark:text-yellow-400/60 font-mono text-xs backdrop-blur-sm bg-slate-900/30 dark:bg-slate-900/40 px-2 py-1 rounded-lg border border-yellow-400/30 transform -rotate-12"
+          style={{ animation: "float 8s ease-in-out infinite 2.5s" }}
+        >
+          ∫∫ f(x,y)dxdy
+        </div>
+        <div
+          className="absolute top-1/4 left-1/3 text-red-400/70 dark:text-red-400/60 font-mono text-sm backdrop-blur-sm bg-slate-900/30 dark:bg-slate-900/40 px-3 py-2 rounded-lg border border-red-400/30 transform rotate-6"
+          style={{ animation: "float 6s ease-in-out infinite 3s" }}
+        >
+          d/dx[f(g(x))] = f'(g(x))·g'(x)
+        </div>
+        <div
+          className="absolute top-2/3 right-1/4 text-indigo-400/70 dark:text-indigo-400/60 font-mono text-xs backdrop-blur-sm bg-slate-900/30 dark:bg-slate-900/40 px-2 py-1 rounded-lg border border-indigo-400/30 transform -rotate-6"
+          style={{ animation: "float 7s ease-in-out infinite 1s" }}
+        >
+          det(A) = ∑σ sgn(σ)∏aᵢσ(ᵢ)
+        </div>
+        <div
+          className="absolute top-1/4 right-1/3 text-violet-400/70 dark:text-violet-400/60 font-mono text-sm backdrop-blur-sm bg-slate-900/30 dark:bg-slate-900/40 px-3 py-2 rounded-lg border border-violet-400/30 transform rotate-9"
+          style={{ animation: "float 6.5s ease-in-out infinite 2s" }}
+        >
+          ∮ F·dr = ∬(∇×F)·dS
+        </div>
+        <div
+          className="absolute bottom-1/4 left-1/4 text-rose-400/70 dark:text-rose-400/60 font-mono text-xs backdrop-blur-sm bg-slate-900/30 dark:bg-slate-900/40 px-2 py-1 rounded-lg border border-rose-400/30 transform -rotate-9"
+          style={{ animation: "float 7.5s ease-in-out infinite 0.8s" }}
+        >
+          Γ(n) = ∫₀^∞ t^(n-1)e^(-t)dt
+        </div>
+      </div>
+
+      {/* <div className="absolute inset-0">
+          <div className="text-emerald-400 dark:text-emerald-600 font-mono text-lg tracking-wider absolute top-10 left-10 rotate-12 animate-pulse">
+            ∫₀^∞ e^(-x²) dx = √π/2
+          </div>
+          <div className="text-blue-400 dark:text-blue-600 font-mono text-sm absolute top-20 right-20 -rotate-6 animate-pulse delay-1000">
+            lim(x→0) (sin x)/x = 1
+          </div>
+          <div className="text-purple-400 dark:text-purple-600 font-mono text-base absolute bottom-32 left-16 rotate-6 animate-pulse delay-2000">
+            ∇²φ = ρ/ε₀
+          </div>
+          <div className="text-yellow-400 dark:text-yellow-600 font-mono text-lg absolute bottom-20 right-24 -rotate-12 animate-pulse delay-3000">
+            e^(iπ) + 1 = 0
+          </div>
+          <div className="text-red-400 dark:text-red-900 font-mono text-sm absolute top-1/3 left-1/4 rotate-3 animate-pulse delay-500">
+            ∂f/∂x = lim(h→0) [f(x+h)-f(x)]/h
+          </div>
+          <div className="text-cyan-400 dark:text-cyan-600 font-mono text-base absolute top-2/3 right-1/3 -rotate-3 animate-pulse delay-1500">
+            ∑(n=1 to ∞) 1/n² = π²/6
+          </div>
+        </div> */}
+
+      {/* Main content */}
+      <div className="relative z-20 text-center px-4 max-w-[1500px] mx-auto">
+        <HyperText
+          animateOnHover={false}
+          duration={1200}
+          className="text-5xl md:text-7xl font-bold mb-6 bg-gradient-to-r from-blue-400 via-purple-400 to-pink-400 bg-clip-text text-transparent"
+        >
+          ACPS Club of Mathematics
+        </HyperText>
+        {/* <HyperText
+          animateOnHover={false}
+          className="text-xl md:text-2xl mb-8 text-gray-200 dark:text-gray-300 font-light"
+        >
+          Think Logical
+        </HyperText> */}
+        <p className="text-xl md:text-2xl mb-8 text-gray-200 dark:text-gray-300 font-light">
+          Think Logical
+        </p>
+        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <Link href="/auth?tab=register">
+            <Button
+              size="lg"
+              variant="outline"
+              className="bg-[#2a3040] border-gray-200 text-gray-200 hover:bg-gray-200 px-8 py-3 text-lg transform-gpu transition-transform duration-300 ease-out hover:scale-[101%] relative w-full max-w-[350px] overflow-hidden"
+            >
+              <ShineBorder shineColor={["#A07CFE", "#FE8FB5", "#FFBE7B"]} />
+              {/* <HyperText
+                animateOnHover={false}
+                className="overflow-hidden py-0 text-base md:text-lg text-gray-200 font-semibold"
+              >
+                Join Now
+              </HyperText> */}
+              Join Now
+            </Button>
+          </Link>
+          <Link href="/resources">
+            <Button
+              size="lg"
+              variant="outline"
+              className="bg-[#2a3040] border-gray-200 text-gray-200 hover:bg-gray-200 px-8 py-3 text-lg transform-gpu transition-transform duration-300 ease-out hover:scale-[101%]"
+            >
+              {/* <HyperText
+                animateOnHover={false}
+                className="overflow-hidden py-0 text-base md:text-lg text-gray-200 font-semibold"
+              >
+                Explore Resources
+              </HyperText> */}
+              Explore Resources
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      {/* Scroll indicator */}
+      <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 z-20">
+        <div className="flex flex-col items-center gap-2">
+          <div className="w-6 h-10 border-2 border-gray-200/60 rounded-full p-1 flex justify-center">
+            <div className="w-1.5 h-3 mt-0.5 bg-gray-200/80 rounded-full animate-bounce" />
+          </div>
+          <span className="text-xs text-gray-200/60 font-light">Scroll</span>
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/components/shared/Navbar.tsx
+++ b/components/shared/Navbar.tsx
@@ -89,7 +89,7 @@ export default function Navbar({ user, profile }: NavbarProps) {
                     : "bg-background/70 backdrop-blur-sm border-b"
             }`}
         >
-            <div className="max-w-6xl mx-auto px-4">
+            <div className="mx-auto px-4 sm:px-6 md:px-8 lg:px-12 xl:px-20 2xl:px-32 3xl:px-40">
                 <div className="flex items-center justify-between h-16">
                     {/* Logo */}
                     <Link className="flex items-center space-x-2" href={"/"}>

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -9,30 +9,34 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { AnimatedThemeToggler } from "./ui/animated-theme-toggler";
 
 export function ThemeToggle() {
     const { setTheme } = useTheme();
 
     return (
-        <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-                <Button variant="outline" size="icon">
-                    <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-                    <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-                    <span className="sr-only">Toggle theme</span>
-                </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => setTheme("light")}>
-                    Light
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setTheme("dark")}>
-                    Dark
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setTheme("system")}>
-                    System
-                </DropdownMenuItem>
-            </DropdownMenuContent>
-        </DropdownMenu>
+        <Button variant={"outline"} size="icon">
+            <AnimatedThemeToggler />
+        </Button>
+        // <DropdownMenu>
+        //     <DropdownMenuTrigger asChild>
+        //         <Button variant="outline" size="icon">
+        //             <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+        //             <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+        //             <span className="sr-only">Toggle theme</span>
+        //         </Button>
+        //     </DropdownMenuTrigger>
+        //     <DropdownMenuContent align="end">
+        //         <DropdownMenuItem onClick={() => setTheme("light")}>
+        //             Light
+        //         </DropdownMenuItem>
+        //         <DropdownMenuItem onClick={() => setTheme("dark")}>
+        //             Dark
+        //         </DropdownMenuItem>
+        //         <DropdownMenuItem onClick={() => setTheme("system")}>
+        //             System
+        //         </DropdownMenuItem>
+        //     </DropdownMenuContent>
+        // </DropdownMenu>
     );
 }

--- a/components/ui/animated-theme-toggler.tsx
+++ b/components/ui/animated-theme-toggler.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { Moon, Sun } from "lucide-react"
+import { flushSync } from "react-dom"
+
+import { cn } from "@/lib/utils"
+
+interface AnimatedThemeTogglerProps
+  extends React.ComponentPropsWithoutRef<"button"> {
+  duration?: number
+}
+
+export const AnimatedThemeToggler = ({
+  className,
+  duration = 400,
+  ...props
+}: AnimatedThemeTogglerProps) => {
+  const [isDark, setIsDark] = useState(false)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    const updateTheme = () => {
+      setIsDark(document.documentElement.classList.contains("dark"))
+    }
+
+    updateTheme()
+
+    const observer = new MutationObserver(updateTheme)
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    })
+
+    return () => observer.disconnect()
+  }, [])
+
+  const toggleTheme = useCallback(async () => {
+    if (!buttonRef.current) return
+
+    await document.startViewTransition(() => {
+      flushSync(() => {
+        const newTheme = !isDark
+        setIsDark(newTheme)
+        document.documentElement.classList.toggle("dark")
+        localStorage.setItem("theme", newTheme ? "dark" : "light")
+      })
+    }).ready
+
+    const { top, left, width, height } =
+      buttonRef.current.getBoundingClientRect()
+    const x = left + width / 2
+    const y = top + height / 2
+    const maxRadius = Math.hypot(
+      Math.max(left, window.innerWidth - left),
+      Math.max(top, window.innerHeight - top)
+    )
+
+    document.documentElement.animate(
+      {
+        clipPath: [
+          `circle(0px at ${x}px ${y}px)`,
+          `circle(${maxRadius}px at ${x}px ${y}px)`,
+        ],
+      },
+      {
+        duration,
+        easing: "ease-in-out",
+        pseudoElement: "::view-transition-new(root)",
+      }
+    )
+  }, [isDark, duration])
+
+  return (
+    <button
+      ref={buttonRef}
+      onClick={toggleTheme}
+      className={cn(className)}
+      {...props}
+    >
+      {isDark ? <Sun /> : <Moon />}
+    </button>
+  )
+}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -74,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -92,7 +92,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
@@ -128,7 +128,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -211,7 +211,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
         className
       )}
       {...props}

--- a/components/ui/hyper-text.tsx
+++ b/components/ui/hyper-text.tsx
@@ -1,0 +1,287 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { AnimatePresence, motion, MotionProps } from "motion/react"
+
+import { cn } from "@/lib/utils"
+
+type CharacterSet = string[] | readonly string[]
+
+interface HyperTextProps extends MotionProps {
+  /** The text content to be animated */
+  children: string
+  /** Optional className for styling */
+  className?: string
+  /** Duration of the animation in milliseconds */
+  duration?: number
+  /** Delay before animation starts in milliseconds */
+  delay?: number
+  /** Component to render as - defaults to div */
+  as?: React.ElementType
+  /** Whether to start animation when element comes into view */
+  startOnView?: boolean
+  /** Whether to trigger animation on hover */
+  animateOnHover?: boolean
+  /** Custom character set for scramble effect. Defaults to uppercase alphabet */
+  characterSet?: CharacterSet
+}
+
+const DEFAULT_CHARACTER_SET = Object.freeze([
+  // Latin uppercase
+  ..."ABCDEFGHIJKLMNOPQRSTUVWXYZ".split(""),
+  // Latin lowercase
+  ..."abcdefghijklmnopqrstuvwxyz".split(""),
+  // Digits
+  ..."0123456789".split(""),
+  // Basic punctuation
+  ",",
+  ".",
+  ":",
+  ";",
+  "?",
+  "!",
+  "-",
+  "_",
+  "=",
+  "+",
+  "*",
+  "/",
+  "\\",
+  "|",
+  "~",
+  "@",
+  "#",
+  "$",
+  "%",
+  "^",
+  "&",
+  "(",
+  ")",
+  "[",
+  "]",
+  "{",
+  "}",
+  "<",
+  ">",
+  "\"",
+  "'",
+  // Common math operators
+  "+",
+  "-",
+  "×",
+  "÷",
+  "=",
+  "≠",
+  "≈",
+  "±",
+  "<",
+  ">",
+  "≤",
+  "≥",
+  "∓",
+  // Greek lowercase (common)
+  "α",
+  "β",
+  "γ",
+  "δ",
+  "ε",
+  "ζ",
+  "η",
+  "θ",
+  "ι",
+  "κ",
+  "λ",
+  "μ",
+  "ν",
+  "ξ",
+  "ο",
+  "π",
+  "ρ",
+  "σ",
+  "τ",
+  "υ",
+  "φ",
+  "χ",
+  "ψ",
+  "ω",
+  // Greek uppercase
+  "Γ",
+  "Δ",
+  "Θ",
+  "Λ",
+  "Ξ",
+  "Π",
+  "Σ",
+  "Φ",
+  "Ψ",
+  "Ω",
+  // Calculus/analysis symbols
+  "∑",
+  "∏",
+  "∫",
+  "∂",
+  "∇",
+  "∞",
+  "√",
+  // Logic / set theory
+  "∧",
+  "∨",
+  "¬",
+  "∈",
+  "∉",
+  "∋",
+  "∅",
+  "⊂",
+  "⊃",
+  "⊆",
+  "⊇",
+  // Arrows and relations
+  "→",
+  "←",
+  "↔",
+  "⇒",
+  "⇔",
+  "⇑",
+  "⇓",
+  // Number sets and math constants
+  "ℕ",
+  "ℤ",
+  "ℚ",
+  "ℝ",
+  "ℂ",
+  // Misc math symbols
+  "°",
+  "‰",
+  "′",
+  "″",
+  "∴",
+  "∵",
+  "|",
+  "‖",
+  "∩",
+  "∪",
+  // Boxing/common punctuation used in math text
+  "–",
+  "—",
+  "•",
+  // Currency (occasionally used)
+  "£",
+  "€",
+  "¥",
+]) as readonly string[]
+
+const getRandomInt = (max: number): number => Math.floor(Math.random() * max)
+
+export function HyperText({
+  children,
+  className,
+  duration = 1000,
+  delay = 0,
+  as: Component = "div",
+  startOnView = false,
+  animateOnHover = true,
+  characterSet = DEFAULT_CHARACTER_SET,
+  ...props
+}: HyperTextProps) {
+  const MotionComponent = motion.create(Component, {
+    forwardMotionProps: true,
+  })
+
+  const [displayText, setDisplayText] = useState<string[]>(() =>
+    children.split("")
+  )
+  const [isAnimating, setIsAnimating] = useState(false)
+  const iterationCount = useRef(0)
+  const elementRef = useRef<HTMLElement>(null)
+
+  const handleAnimationTrigger = () => {
+    if (animateOnHover && !isAnimating) {
+      iterationCount.current = 0
+      setIsAnimating(true)
+    }
+  }
+
+  // Handle animation start based on view or delay
+  useEffect(() => {
+    if (!startOnView) {
+      const startTimeout = setTimeout(() => {
+        setIsAnimating(true)
+      }, delay)
+      return () => clearTimeout(startTimeout)
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setTimeout(() => {
+            setIsAnimating(true)
+          }, delay)
+          observer.disconnect()
+        }
+      },
+      { threshold: 0.1, rootMargin: "-30% 0px -30% 0px" }
+    )
+
+    if (elementRef.current) {
+      observer.observe(elementRef.current)
+    }
+
+    return () => observer.disconnect()
+  }, [delay, startOnView])
+
+  // Handle scramble animation
+  useEffect(() => {
+    if (!isAnimating) return
+
+    const maxIterations = children.length
+    const startTime = performance.now()
+    let animationFrameId: number
+
+    const animate = (currentTime: number) => {
+      const elapsed = currentTime - startTime
+      const progress = Math.min(elapsed / duration, 1)
+
+      iterationCount.current = progress * maxIterations
+
+      setDisplayText((currentText) =>
+        currentText.map((letter, index) =>
+          letter === " "
+            ? letter
+            : index <= iterationCount.current
+              ? children[index]
+              : characterSet[getRandomInt(characterSet.length)]
+        )
+      )
+
+      if (progress < 1) {
+        animationFrameId = requestAnimationFrame(animate)
+      } else {
+        setIsAnimating(false)
+      }
+    }
+
+    animationFrameId = requestAnimationFrame(animate)
+
+    return () => cancelAnimationFrame(animationFrameId)
+  }, [children, duration, isAnimating, characterSet])
+
+  return (
+    <MotionComponent
+      ref={elementRef}
+      className={cn("overflow-hidden py-2 text-4xl font-bold", className)}
+      onMouseEnter={handleAnimationTrigger}
+      {...props}
+    >
+      <AnimatePresence>
+        {displayText.map((letter, index) => (
+          <motion.span
+            key={index}
+            className={cn("", letter === " " ? "w-3" : "")}
+          >
+            {letter.toUpperCase()}
+          </motion.span>
+        ))}
+      </AnimatePresence>
+    </MotionComponent>
+  )
+}

--- a/components/ui/particles.tsx
+++ b/components/ui/particles.tsx
@@ -1,0 +1,314 @@
+"use client"
+
+import React, {
+  ComponentPropsWithoutRef,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+
+import { cn } from "@/lib/utils"
+
+interface MousePosition {
+  x: number
+  y: number
+}
+
+function MousePosition(): MousePosition {
+  const [mousePosition, setMousePosition] = useState<MousePosition>({
+    x: 0,
+    y: 0,
+  })
+
+  useEffect(() => {
+    const handleMouseMove = (event: MouseEvent) => {
+      setMousePosition({ x: event.clientX, y: event.clientY })
+    }
+
+    window.addEventListener("mousemove", handleMouseMove)
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove)
+    }
+  }, [])
+
+  return mousePosition
+}
+
+interface ParticlesProps extends ComponentPropsWithoutRef<"div"> {
+  className?: string
+  quantity?: number
+  staticity?: number
+  ease?: number
+  size?: number
+  refresh?: boolean
+  color?: string
+  vx?: number
+  vy?: number
+}
+
+function hexToRgb(hex: string): number[] {
+  hex = hex.replace("#", "")
+
+  if (hex.length === 3) {
+    hex = hex
+      .split("")
+      .map((char) => char + char)
+      .join("")
+  }
+
+  const hexInt = parseInt(hex, 16)
+  const red = (hexInt >> 16) & 255
+  const green = (hexInt >> 8) & 255
+  const blue = hexInt & 255
+  return [red, green, blue]
+}
+
+type Circle = {
+  x: number
+  y: number
+  translateX: number
+  translateY: number
+  size: number
+  alpha: number
+  targetAlpha: number
+  dx: number
+  dy: number
+  magnetism: number
+}
+
+export const Particles: React.FC<ParticlesProps> = ({
+  className = "",
+  quantity = 100,
+  staticity = 50,
+  ease = 50,
+  size = 0.4,
+  refresh = false,
+  color = "#ffffff",
+  vx = 0,
+  vy = 0,
+  ...props
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const canvasContainerRef = useRef<HTMLDivElement>(null)
+  const context = useRef<CanvasRenderingContext2D | null>(null)
+  const circles = useRef<Circle[]>([])
+  const mousePosition = MousePosition()
+  const mouse = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
+  const canvasSize = useRef<{ w: number; h: number }>({ w: 0, h: 0 })
+  const dpr = typeof window !== "undefined" ? window.devicePixelRatio : 1
+  const rafID = useRef<number | null>(null)
+  const resizeTimeout = useRef<NodeJS.Timeout | null>(null)
+
+  useEffect(() => {
+    if (canvasRef.current) {
+      context.current = canvasRef.current.getContext("2d")
+    }
+    initCanvas()
+    animate()
+
+    const handleResize = () => {
+      if (resizeTimeout.current) {
+        clearTimeout(resizeTimeout.current)
+      }
+      resizeTimeout.current = setTimeout(() => {
+        initCanvas()
+      }, 200)
+    }
+
+    window.addEventListener("resize", handleResize)
+
+    return () => {
+      if (rafID.current != null) {
+        window.cancelAnimationFrame(rafID.current)
+      }
+      if (resizeTimeout.current) {
+        clearTimeout(resizeTimeout.current)
+      }
+      window.removeEventListener("resize", handleResize)
+    }
+  }, [color])
+
+  useEffect(() => {
+    onMouseMove()
+  }, [mousePosition.x, mousePosition.y])
+
+  useEffect(() => {
+    initCanvas()
+  }, [refresh])
+
+  const initCanvas = () => {
+    resizeCanvas()
+    drawParticles()
+  }
+
+  const onMouseMove = () => {
+    if (canvasRef.current) {
+      const rect = canvasRef.current.getBoundingClientRect()
+      const { w, h } = canvasSize.current
+      const x = mousePosition.x - rect.left - w / 2
+      const y = mousePosition.y - rect.top - h / 2
+      const inside = x < w / 2 && x > -w / 2 && y < h / 2 && y > -h / 2
+      if (inside) {
+        mouse.current.x = x
+        mouse.current.y = y
+      }
+    }
+  }
+
+  const resizeCanvas = () => {
+    if (canvasContainerRef.current && canvasRef.current && context.current) {
+      canvasSize.current.w = canvasContainerRef.current.offsetWidth
+      canvasSize.current.h = canvasContainerRef.current.offsetHeight
+
+      canvasRef.current.width = canvasSize.current.w * dpr
+      canvasRef.current.height = canvasSize.current.h * dpr
+      canvasRef.current.style.width = `${canvasSize.current.w}px`
+      canvasRef.current.style.height = `${canvasSize.current.h}px`
+      context.current.scale(dpr, dpr)
+
+      // Clear existing particles and create new ones with exact quantity
+      circles.current = []
+      for (let i = 0; i < quantity; i++) {
+        const circle = circleParams()
+        drawCircle(circle)
+      }
+    }
+  }
+
+  const circleParams = (): Circle => {
+    const x = Math.floor(Math.random() * canvasSize.current.w)
+    const y = Math.floor(Math.random() * canvasSize.current.h)
+    const translateX = 0
+    const translateY = 0
+    const pSize = Math.floor(Math.random() * 2) + size
+    const alpha = 0
+    const targetAlpha = parseFloat((Math.random() * 0.6 + 0.1).toFixed(1))
+    const dx = (Math.random() - 0.5) * 0.1
+    const dy = (Math.random() - 0.5) * 0.1
+    const magnetism = 0.1 + Math.random() * 4
+    return {
+      x,
+      y,
+      translateX,
+      translateY,
+      size: pSize,
+      alpha,
+      targetAlpha,
+      dx,
+      dy,
+      magnetism,
+    }
+  }
+
+  const rgb = hexToRgb(color)
+
+  const drawCircle = (circle: Circle, update = false) => {
+    if (context.current) {
+      const { x, y, translateX, translateY, size, alpha } = circle
+      context.current.translate(translateX, translateY)
+      context.current.beginPath()
+      context.current.arc(x, y, size, 0, 2 * Math.PI)
+      context.current.fillStyle = `rgba(${rgb.join(", ")}, ${alpha})`
+      context.current.fill()
+      context.current.setTransform(dpr, 0, 0, dpr, 0, 0)
+
+      if (!update) {
+        circles.current.push(circle)
+      }
+    }
+  }
+
+  const clearContext = () => {
+    if (context.current) {
+      context.current.clearRect(
+        0,
+        0,
+        canvasSize.current.w,
+        canvasSize.current.h
+      )
+    }
+  }
+
+  const drawParticles = () => {
+    clearContext()
+    const particleCount = quantity
+    for (let i = 0; i < particleCount; i++) {
+      const circle = circleParams()
+      drawCircle(circle)
+    }
+  }
+
+  const remapValue = (
+    value: number,
+    start1: number,
+    end1: number,
+    start2: number,
+    end2: number
+  ): number => {
+    const remapped =
+      ((value - start1) * (end2 - start2)) / (end1 - start1) + start2
+    return remapped > 0 ? remapped : 0
+  }
+
+  const animate = () => {
+    clearContext()
+    circles.current.forEach((circle: Circle, i: number) => {
+      // Handle the alpha value
+      const edge = [
+        circle.x + circle.translateX - circle.size, // distance from left edge
+        canvasSize.current.w - circle.x - circle.translateX - circle.size, // distance from right edge
+        circle.y + circle.translateY - circle.size, // distance from top edge
+        canvasSize.current.h - circle.y - circle.translateY - circle.size, // distance from bottom edge
+      ]
+      const closestEdge = edge.reduce((a, b) => Math.min(a, b))
+      const remapClosestEdge = parseFloat(
+        remapValue(closestEdge, 0, 20, 0, 1).toFixed(2)
+      )
+      if (remapClosestEdge > 1) {
+        circle.alpha += 0.02
+        if (circle.alpha > circle.targetAlpha) {
+          circle.alpha = circle.targetAlpha
+        }
+      } else {
+        circle.alpha = circle.targetAlpha * remapClosestEdge
+      }
+      circle.x += circle.dx + vx
+      circle.y += circle.dy + vy
+      circle.translateX +=
+        (mouse.current.x / (staticity / circle.magnetism) - circle.translateX) /
+        ease
+      circle.translateY +=
+        (mouse.current.y / (staticity / circle.magnetism) - circle.translateY) /
+        ease
+
+      drawCircle(circle, true)
+
+      // circle gets out of the canvas
+      if (
+        circle.x < -circle.size ||
+        circle.x > canvasSize.current.w + circle.size ||
+        circle.y < -circle.size ||
+        circle.y > canvasSize.current.h + circle.size
+      ) {
+        // remove the circle from the array
+        circles.current.splice(i, 1)
+        // create a new circle
+        const newCircle = circleParams()
+        drawCircle(newCircle)
+      }
+    })
+    rafID.current = window.requestAnimationFrame(animate)
+  }
+
+  return (
+    <div
+      className={cn("pointer-events-none", className)}
+      ref={canvasContainerRef}
+      aria-hidden="true"
+      {...props}
+    >
+      <canvas ref={canvasRef} className="size-full" />
+    </div>
+  )
+}

--- a/components/ui/shine-border.tsx
+++ b/components/ui/shine-border.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+interface ShineBorderProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Width of the border in pixels
+   * @default 1
+   */
+  borderWidth?: number
+  /**
+   * Duration of the animation in seconds
+   * @default 14
+   */
+  duration?: number
+  /**
+   * Color of the border, can be a single color or an array of colors
+   * @default "#000000"
+   */
+  shineColor?: string | string[]
+}
+
+/**
+ * Shine Border
+ *
+ * An animated background border effect component with configurable properties.
+ */
+export function ShineBorder({
+  borderWidth = 1,
+  duration = 14,
+  shineColor = "#000000",
+  className,
+  style,
+  ...props
+}: ShineBorderProps) {
+  return (
+    <div
+      style={
+        {
+          "--border-width": `${borderWidth}px`,
+          "--duration": `${duration}s`,
+          backgroundImage: `radial-gradient(transparent,transparent, ${
+            Array.isArray(shineColor) ? shineColor.join(",") : shineColor
+          },transparent,transparent)`,
+          backgroundSize: "300% 300%",
+          mask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+          WebkitMask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+          WebkitMaskComposite: "xor",
+          maskComposite: "exclude",
+          padding: "var(--border-width)",
+          ...style,
+        } as React.CSSProperties
+      }
+      className={cn(
+        "motion-safe:animate-shine pointer-events-none absolute inset-0 size-full rounded-[inherit] will-change-[background-position]",
+        className
+      )}
+      {...props}
+    />
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
                 "framer-motion": "^12.23.6",
                 "lowlight": "^3.3.0",
                 "lucide-react": "^0.525.0",
+                "motion": "^12.23.22",
                 "next": "15.4.1",
                 "next-themes": "^0.4.6",
                 "pdfjs-dist": "^5.4.149",
@@ -4038,12 +4039,12 @@
             }
         },
         "node_modules/framer-motion": {
-            "version": "12.23.6",
-            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.6.tgz",
-            "integrity": "sha512-dsJ389QImVE3lQvM8Mnk99/j8tiZDM/7706PCqvkQ8sSCnpmWxsgX+g0lj7r5OBVL0U36pIecCTBoIWcM2RuKw==",
+            "version": "12.23.22",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.22.tgz",
+            "integrity": "sha512-ZgGvdxXCw55ZYvhoZChTlG6pUuehecgvEAJz0BHoC5pQKW1EC5xf1Mul1ej5+ai+pVY0pylyFfdl45qnM1/GsA==",
             "license": "MIT",
             "dependencies": {
-                "motion-dom": "^12.23.6",
+                "motion-dom": "^12.23.21",
                 "motion-utils": "^12.23.6",
                 "tslib": "^2.4.0"
             },
@@ -4558,10 +4559,36 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/motion": {
+            "version": "12.23.22",
+            "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.22.tgz",
+            "integrity": "sha512-iSq6X9vLHbeYwmHvhK//+U74ROaPnZmBuy60XZzqNl0QtZkWfoZyMDHYnpKuWFv0sNMqHgED8aCXk94LCoQPGg==",
+            "license": "MIT",
+            "dependencies": {
+                "framer-motion": "^12.23.22",
+                "tslib": "^2.4.0"
+            },
+            "peerDependencies": {
+                "@emotion/is-prop-valid": "*",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/is-prop-valid": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/motion-dom": {
-            "version": "12.23.6",
-            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.6.tgz",
-            "integrity": "sha512-G2w6Nw7ZOVSzcQmsdLc0doMe64O/Sbuc2bVAbgMz6oP/6/pRStKRiVRV4bQfHp5AHYAKEGhEdVHTM+R3FDgi5w==",
+            "version": "12.23.21",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.21.tgz",
+            "integrity": "sha512-5xDXx/AbhrfgsQmSE7YESMn4Dpo6x5/DTZ4Iyy4xqDvVHWvFVoV+V2Ri2S/ksx+D40wrZ7gPYiMWshkdoqNgNQ==",
             "license": "MIT",
             "dependencies": {
                 "motion-utils": "^12.23.6"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "framer-motion": "^12.23.6",
         "lowlight": "^3.3.0",
         "lucide-react": "^0.525.0",
+        "motion": "^12.23.22",
         "next": "15.4.1",
         "next-themes": "^0.4.6",
         "pdfjs-dist": "^5.4.149",


### PR DESCRIPTION
This pull request introduces several visual and structural improvements across the website, focusing on enhancing the user interface, adding new features, and refining the overall user experience. The most notable updates include a visually dynamic hero section, a new contributors section on the About page, global style enhancements, and UI consistency improvements.

**UI/UX Enhancements:**

- Major redesign of the `HeroSection` with animated mathematical symbols, floating equations, particle effects, and improved scroll indicator for a more engaging landing experience. (`components/home/HeroSection.tsx`)
- The navigation bar (`Navbar`) now uses more responsive padding classes for better adaptability across screen sizes. (`components/shared/Navbar.tsx`)
- The theme toggle button is simplified to use an animated icon, removing the dropdown menu for a cleaner look. (`components/theme-toggle.tsx`)

**New Features:**

- Added a `Contributors` section to the About page, which dynamically fetches and displays GitHub contributors with avatars and links to their profiles. (`components/about/Contributors.tsx`, `app/about/page.tsx`) [[1]](diffhunk://#diff-3c8623db5c2ca8bfae9ba922005444c3126f360e4091c5de7ef5e1fa7cd963a0R1-R87) [[2]](diffhunk://#diff-06f49e3158547ee7b6e5ad074bcb5d474ecd3b8d7b1418c4ab1d89973e22c5edR2) [[3]](diffhunk://#diff-06f49e3158547ee7b6e5ad074bcb5d474ecd3b8d7b1418c4ab1d89973e22c5edR719-R720)

**Styling and Visual Improvements:**

- Global styles now import the Montserrat font, set it as the default, and add custom cursor and animation styles, including new keyframes for "shine" and "float" effects. (`app/globals.css`) [[1]](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392R1) [[2]](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392R217-R225) [[3]](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392R250-R273)
- Updated the About page's constitution link to point to a new Supabase-hosted PDF. (`app/about/page.tsx`)

**Configuration Updates:**

- Added MagicUI registry and explicitly set the icon library to Lucide in the component config. (`components.json`)

**Summary of Most Important Changes:**

**Visual and User Experience Improvements**
- Redesigned `HeroSection` with animated math symbols, floating equations, and interactive background effects for an engaging landing page.
- Enhanced navigation bar with more responsive and adaptive padding for better layout across devices.
- Simplified theme toggle button with an animated icon, removing the dropdown for a more streamlined UI.

**New Features**
- Introduced a dynamic `Contributors` section on the About page, displaying GitHub contributors with avatars and profile links. [[1]](diffhunk://#diff-3c8623db5c2ca8bfae9ba922005444c3126f360e4091c5de7ef5e1fa7cd963a0R1-R87) [[2]](diffhunk://#diff-06f49e3158547ee7b6e5ad074bcb5d474ecd3b8d7b1418c4ab1d89973e22c5edR2) [[3]](diffhunk://#diff-06f49e3158547ee7b6e5ad074bcb5d474ecd3b8d7b1418c4ab1d89973e22c5edR719-R720)

**Styling and Configuration**
- Applied global style improvements: imported Montserrat font, set as default, added custom cursor and animation keyframes, and refined UI element styles. [[1]](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392R1) [[2]](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392R217-R225) [[3]](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392R250-R273)
- Updated About page constitution link to a new Supabase PDF location.
- Updated component configuration for icon library and MagicUI registry.

## Screenshots

<img width="1920" height="973" alt="image" src="https://github.com/user-attachments/assets/8e24896a-def6-4d34-b0ba-e5b37067f142" />

<img width="1914" height="971" alt="image" src="https://github.com/user-attachments/assets/58122568-4776-4db3-8e8b-b1a893bb1ded" />

## Tickets

- 10, 13-16, 18-21

